### PR TITLE
compare new props with state.value instead of old props.value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-indie-slider",
-  "version": "0.11.0-SNAPSHOT",
+  "version": "0.11.0-SNAPSHOT.1",
   "description": "A pure JavaScript <Slider /> component for react-native",
   "main": "lib/Slider.js",
   "files": [

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -265,7 +265,7 @@ export default class Slider extends PureComponent {
   };
 
   componentWillReceiveProps(nextProps) {
-    var oldValues = this.props.value;
+    var oldValues = this.state.value;
     var newValues = nextProps.value;
     
     if (!Array.isArray(newValues))


### PR DESCRIPTION
@idealllee @drhops 
If we try to set slider prop's value to 80, then move the slider via dragging the thumb, then try setting the prop's value back to 80, the slider won't update.
Changed so that we base the comparison off the `state.value` instead of `props.value`.